### PR TITLE
Update FindFrontableDomains.py

### DIFF
--- a/FindFrontableDomains.py
+++ b/FindFrontableDomains.py
@@ -23,7 +23,7 @@ class ThreadLookup(threading.Thread):
 
                 dns.resolver.default_resolver = dns.resolver.Resolver(configure=False)
                 dns.resolver.default_resolver.nameservers = ['209.244.0.3', '209.244.0.4','64.6.64.6','64.6.65.6', '8.8.8.8', '8.8.4.4','84.200.69.80', '84.200.70.40', '8.26.56.26', '8.20.247.20', '208.67.222.222', '208.67.220.220','199.85.126.10', '199.85.127.10', '81.218.119.11', '209.88.198.133', '195.46.39.39', '195.46.39.40', '96.90.175.167', '193.183.98.154','208.76.50.50', '208.76.51.51', '216.146.35.35', '216.146.36.36', '37.235.1.174', '37.235.1.177', '198.101.242.72', '23.253.163.53', '77.88.8.8', '77.88.8.1', '91.239.100.100', '89.233.43.71', '74.82.42.42', '109.69.8.51']
-                query = dns.resolver.query(hostname, 'a')
+                query = dns.resolver.resolve(hostname, 'a')
                 # Iterate through response and check for potential CNAMES
                 for i in query.response.answer:
                     for j in i.items:


### PR DESCRIPTION
Fix fatal deprecation error

```
Starting search for frontable domains...
FindFrontableDomains.py:26: DeprecationWarning: please use dns.resolver.resolve() instead
  query = dns.resolver.query(hostname, 'a')
Search complete!
```