### PR TITLE
* Add azurefd.net to frontable checks

### DIFF
--- a/FindFrontableDomains.py
+++ b/FindFrontableDomains.py
@@ -38,6 +38,8 @@ class ThreadLookup(threading.Thread):
                             print("Azure Frontable domain found: " + str(hostname) + " " + str(target))
                         elif 'azureedge.net' in target:
                             print("Azure Frontable domain found: " + str(hostname) + " " + str(target))
+                        elif 'azurefd.net' in target:
+                            print("Azure Frontable domain found: " + str(hostname) + " " + str(target))
                         elif 'a248.e.akamai.net' in target:
                             print("Akamai frontable domain found: " + str(hostname) + " " + str(target))
                         elif 'secure.footprint.net' in target:


### PR DESCRIPTION
Azure Front Door is another frontable service that can be used. This pull request adds it's domain to the checks done by FindFrontableDomains. More info on Azure Front Door can be found at https://www.fortalicesolutions.com/posts/hiding-behind-the-front-door-with-azure-domain-fronting