### PR TITLE
Fix DeprecationWarning setDaemon()

### DIFF
--- a/FindFrontableDomains.py
+++ b/FindFrontableDomains.py
@@ -115,7 +115,7 @@ def main():
     # spawn a pool of threads and pass them queue instance
     for i in range(threads):
         t = ThreadLookup(q)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
     
     q.join()


### PR DESCRIPTION
The output contained this warning message:

`FindFrontableDomains.py:118: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead`

I adjusted the code to set the daemon property instead of using the setDaemon() function.